### PR TITLE
Support Django 4.1.7 and 4.2 (#1)

### DIFF
--- a/envconfig/setting_types.py
+++ b/envconfig/setting_types.py
@@ -32,6 +32,7 @@ _setting_types: Dict[str, List[type]] = {
     'DATABASE_ROUTERS': [list],
     'DATA_UPLOAD_MAX_MEMORY_SIZE': [type(None), int],
     'DATA_UPLOAD_MAX_NUMBER_FIELDS': [type(None), int],
+    'DATA_UPLOAD_MAX_NUMBER_FILES': [int],
     'DATETIME_FORMAT': [str],
     'DATETIME_INPUT_FORMATS': [list],
     'DATE_FORMAT': [str],
@@ -44,7 +45,7 @@ _setting_types: Dict[str, List[type]] = {
     'DEFAULT_CONTENT_TYPE': [str],  # deprecated v2.0, removed v3.0
     'DEFAULT_EXCEPTION_REPORTER': [str],
     'DEFAULT_EXCEPTION_REPORTER_FILTER': [str],
-    'DEFAULT_FILE_STORAGE': [str],
+    'DEFAULT_FILE_STORAGE': [str],  # deprecated v4.2
     'DEFAULT_FROM_EMAIL': [str],
     'DEFAULT_HASHING_ALGORITHM': [str],
     'DEFAULT_INDEX_TABLESPACE': [str],
@@ -138,9 +139,10 @@ _setting_types: Dict[str, List[type]] = {
     'SILENCED_SYSTEM_CHECKS': [list],
     'STATICFILES_DIRS': [list],
     'STATICFILES_FINDERS': [list],
-    'STATICFILES_STORAGE': [str],
+    'STATICFILES_STORAGE': [str],  # deprecated v4.2
     'STATIC_ROOT': [type(None), str],
     'STATIC_URL': [type(None), str],
+    'STORAGES': [dict],
     'TEMPLATES': [list],
     # 'TEMPLATE_DIRS': [list],  # deprecated v1.8, removed v1.10
     'TEST_NON_SERIALIZED_APPS': [list],

--- a/tox.ini
+++ b/tox.ini
@@ -2,10 +2,10 @@
 isolated_build = True
 envlist =
     py36-django{111,20,21,22,30,31,32}-pytest
-    py38-django{22,30,31,32,40,41}-pytest
-    py39-django{22,30,31,32,40,41}-pytest
-    py310-django{32,40,41}-pytest
-    py311-django41-pytest
+    py38-django{22,30,31,32,40,41,42}-pytest
+    py39-django{22,30,31,32,40,41,42}-pytest
+    py310-django{32,40,41,42}-pytest
+    py311-django{41,42}-pytest
     py311-flake8
     py311-mypy
 
@@ -37,7 +37,8 @@ deps =
     py310-django32: Django>=3.2.9,<3.3
     py{38,39,310}-django40: Django>=4.0,<4.1
     py{38,39,310}-django41: Django>=4.1,<4.2
-    py311-django41: Django>=4.1.3
+    py311-django41: Django>=4.1.3,<4.2
+    py{38,39,310,311}-django42: Django>=4.2,<4.3
     flake8: flake8
     mypy: mypy
     pytest: -r{toxinidir}/requirements.txt


### PR DESCRIPTION
New settings:
- `DATA_UPLOAD_MAX_NUMBER_FILES` (4.1.7)
- `STORAGES` (4.2)